### PR TITLE
docs: fix Darija typo (kat3reb → kat3ref)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Dwaz - Discord Wrapper API for Zwafriya
-> Dwaz 5alina men lmar9a kat3reb tsaybe bot b dwaz?
+> Dwaz 5alina men lmar9a kat3ref tsaybe bot b dwaz?
 
 ## Overview
 


### PR DESCRIPTION
Replace "kat3reb" with "kat3ref" in README sentence:
“Dwaz 5alina men lmar9a kat3ref tsaybe bot b Dwaz?”
